### PR TITLE
Refs [TASK][92086][Admin][Quản lý yêu cầu mượn sách] Tự động phân bổ sách vật lý

### DIFF
--- a/library_management/src/main/java/com/group2/library_management/dto/response/BorrowingReceiptResponse.java
+++ b/library_management/src/main/java/com/group2/library_management/dto/response/BorrowingReceiptResponse.java
@@ -19,15 +19,25 @@ public record BorrowingReceiptResponse(
         LocalDateTime updatedAt,
         BorrowingStatus status,
         String rejectedReason,
-        List<BorrowingDetailResponse> borrowingDetails) {
+        List<BorrowingDetailResponse> borrowingDetails,
+        List<BorrowingRequestDetailResponse> borrowingRequestDetails) {
     public static BorrowingReceiptResponse fromEntity(BorrowingReceipt entity,
             boolean includeDetails) {
         List<BorrowingDetailResponse> details = Collections.emptyList();
+        List<BorrowingRequestDetailResponse> requestDetails = Collections.emptyList();
 
-        if (includeDetails && entity.getBorrowingDetails() instanceof List<?> list && !list.isEmpty()) {
-            details = entity.getBorrowingDetails().stream()
-                    .map(BorrowingDetailResponse::fromEntity)
-                    .collect(Collectors.toList());
+        if (includeDetails) {
+            if (entity.getBorrowingDetails() != null && !entity.getBorrowingDetails().isEmpty()) {
+                details = entity.getBorrowingDetails().stream()
+                        .map(BorrowingDetailResponse::fromEntity)
+                        .collect(Collectors.toList());
+            }
+            
+            if (entity.getBorrowingRequestDetails() != null && !entity.getBorrowingRequestDetails().isEmpty()) {
+                requestDetails = entity.getBorrowingRequestDetails().stream()
+                        .map(BorrowingRequestDetailResponse::fromEntity)
+                        .collect(Collectors.toList());
+            }
         }
 
         return new BorrowingReceiptResponse(
@@ -41,7 +51,8 @@ public record BorrowingReceiptResponse(
                 entity.getUpdatedAt(),
                 entity.getStatus(),
                 entity.getRejectedReason(),
-                details);
+                details,
+                requestDetails);
     }
 
     public static BorrowingReceiptResponse fromEntity(BorrowingReceipt entity) {

--- a/library_management/src/main/java/com/group2/library_management/dto/response/BorrowingRequestDetailResponse.java
+++ b/library_management/src/main/java/com/group2/library_management/dto/response/BorrowingRequestDetailResponse.java
@@ -1,6 +1,26 @@
 package com.group2.library_management.dto.response;
 
+import com.group2.library_management.entity.BorrowingRequestDetail;
+import lombok.Builder;
+
+@Builder
 public record BorrowingRequestDetailResponse(
-    Integer editionId,
-    int quantity
-) {}
+        Integer id,
+        Integer editionId,
+        String title,
+        String isbn,
+        int quantity
+) {
+    public static BorrowingRequestDetailResponse fromEntity(BorrowingRequestDetail entity) {
+        if (entity == null || entity.getEdition() == null) {
+            return BorrowingRequestDetailResponse.builder().build();
+        }
+        return BorrowingRequestDetailResponse.builder()
+                .id(entity.getId())
+                .editionId(entity.getEdition().getId())
+                .title(entity.getEdition().getTitle())
+                .isbn(entity.getEdition().getIsbn())
+                .quantity(entity.getQuantity())
+                .build();
+    }
+}

--- a/library_management/src/main/java/com/group2/library_management/repository/BookInstanceRepository.java
+++ b/library_management/src/main/java/com/group2/library_management/repository/BookInstanceRepository.java
@@ -24,6 +24,8 @@ public interface BookInstanceRepository extends ListCrudRepository<BookInstance,
     // Count active copies of an edition
     long countByEditionIdAndDeleteAtIsNull(Integer editionId);
 
+    long countByEditionIdAndStatus(Integer editionId, BookStatus status);
+
     // Count all copies (including soft-deleted) of an edition — use native query to bypass entity-level @Where
     @Query(value = "SELECT COUNT(*) FROM book_instances WHERE edition_id = :editionId", nativeQuery = true)
     long countAllByEditionIdNative(@Param("editionId") Integer editionId);
@@ -34,6 +36,9 @@ public interface BookInstanceRepository extends ListCrudRepository<BookInstance,
     @Query(value = "SELECT EXISTS(SELECT 1 FROM book_instances WHERE edition_id = :editionId)", 
            nativeQuery = true)
     Integer existsByEditionIdNative(@Param("editionId") Integer editionId);
+
+    @Query("SELECT bi FROM BookInstance bi WHERE bi.edition.id = :editionId AND bi.status = :status ORDER BY bi.acquiredDate ASC")
+    List<BookInstance> findByEditionIdAndStatusOrderByAcquiredDateAsc(@Param("editionId") Integer editionId, @Param("status") BookStatus status);
 
     // default method thực hiện convert sang boolean
     default boolean existsByEditionId(Integer editionId) {

--- a/library_management/src/main/java/com/group2/library_management/repository/BorrowingReceiptRepository.java
+++ b/library_management/src/main/java/com/group2/library_management/repository/BorrowingReceiptRepository.java
@@ -19,7 +19,8 @@ public interface BorrowingReceiptRepository extends JpaRepository<BorrowingRecei
 
     @EntityGraph(attributePaths = {
             "user",
-            "borrowingDetails.bookInstance.edition"
+            "borrowingDetails.bookInstance.edition",
+            "borrowingRequestDetails.edition"
     })
     Optional<BorrowingReceipt> findById(Integer id);
 

--- a/library_management/src/main/java/com/group2/library_management/repository/BorrowingRequestDetailRepository.java
+++ b/library_management/src/main/java/com/group2/library_management/repository/BorrowingRequestDetailRepository.java
@@ -1,5 +1,6 @@
 package com.group2.library_management.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,4 +8,5 @@ import com.group2.library_management.entity.BorrowingRequestDetail;
 
 @Repository
 public interface BorrowingRequestDetailRepository extends JpaRepository<BorrowingRequestDetail, Integer> {
+    List<BorrowingRequestDetail> findByBorrowingReceiptId(Integer borrowingReceiptId);
 }

--- a/library_management/src/main/java/com/group2/library_management/service/impl/BorrowingReceiptServiceImpl.java
+++ b/library_management/src/main/java/com/group2/library_management/service/impl/BorrowingReceiptServiceImpl.java
@@ -7,6 +7,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
@@ -19,6 +21,7 @@ import com.group2.library_management.dto.response.BorrowingReceiptResponse;
 import com.group2.library_management.entity.BookInstance;
 import com.group2.library_management.entity.BorrowingDetail;
 import com.group2.library_management.entity.BorrowingReceipt;
+import com.group2.library_management.entity.BorrowingRequestDetail;
 import com.group2.library_management.entity.Edition;
 import com.group2.library_management.entity.User;
 import com.group2.library_management.entity.enums.BookStatus;
@@ -26,6 +29,7 @@ import com.group2.library_management.entity.enums.BorrowingStatus;
 import com.group2.library_management.repository.BookInstanceRepository;
 import com.group2.library_management.repository.BorrowingDetailRepository;
 import com.group2.library_management.repository.BorrowingReceiptRepository;
+import com.group2.library_management.repository.BorrowingRequestDetailRepository;
 import com.group2.library_management.repository.EditionRepository;
 import com.group2.library_management.service.BorrowingReceiptService;
 
@@ -41,7 +45,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class BorrowingReceiptServiceImpl implements BorrowingReceiptService {
 
-    private static final String APPROVAL_ERROR_PREFIX = "Không thể phê duyệt: Các sách sau không còn sẵn sàng: ";
     private static final String RECEIPT_NOT_FOUND_ERROR = "Không tìm thấy phiếu mượn với ID: ";
     private static final String PENDING_STATUS_REQUIRED_ERROR = "Chỉ có thể phê duyệt yêu cầu đang ở trạng thái chờ phê duyệt";
     private static final String REJECTION_STATUS_REQUIRED_ERROR = "Chỉ có thể từ chối yêu cầu đang ở trạng thái chờ phê duyệt";
@@ -51,6 +54,8 @@ public class BorrowingReceiptServiceImpl implements BorrowingReceiptService {
     private final BookInstanceRepository bookInstanceRepository;
     private final EditionRepository editionRepository;
     private final BorrowingDetailRepository borrowingDetailRepository;
+    private final BorrowingRequestDetailRepository borrowingRequestDetailRepository;
+    private final MessageSource messageSource;
 
     private final Map<Integer, LocalDateTime> detailExtendedDueDates = new HashMap<>();
 
@@ -149,44 +154,90 @@ public class BorrowingReceiptServiceImpl implements BorrowingReceiptService {
 
         // Check current status
         if (receipt.getStatus() != BorrowingStatus.PENDING) {
-            throw new IllegalStateException(PENDING_STATUS_REQUIRED_ERROR);
+            throw new IllegalStateException(messageSource.getMessage(
+                "admin.borrowing.error.pending_status_required", 
+                null, 
+                PENDING_STATUS_REQUIRED_ERROR, 
+                LocaleContextHolder.getLocale()));
         }
 
-        // Validate all book instances are available before approving
-        List<BookInstance> unavailableBooks = receipt.getBorrowingDetails().stream()
-                .map(BorrowingDetail::getBookInstance)
-                .filter(bookInstance -> bookInstance.getStatus() != BookStatus.AVAILABLE).toList();
+        // Get borrowing request details instead of borrowing details
+        List<BorrowingRequestDetail> requestDetails = borrowingRequestDetailRepository
+                .findByBorrowingReceiptId(receipt.getId());
 
-        // If any book is not available, reject the approval
-        if (!unavailableBooks.isEmpty()) {
-            String errorMessage = APPROVAL_ERROR_PREFIX + unavailableBooks.stream()
-                    .map(this::formatBookInstanceError).collect(Collectors.joining(", "));
+        if (requestDetails.isEmpty()) {
+            throw new IllegalStateException(messageSource.getMessage(
+                "admin.borrowing.error.no_request_details", 
+                null, 
+                "Không tìm thấy chi tiết yêu cầu mượn", 
+                LocaleContextHolder.getLocale()));
+        }
+
+        // Check availability for all editions before processing
+        List<String> insufficientBooks = new ArrayList<>();
+        Map<Integer, List<BookInstance>> availableInstancesMap = new HashMap<>();
+
+        for (BorrowingRequestDetail requestDetail : requestDetails) {
+            Edition edition = requestDetail.getEdition();
+            int requestedQuantity = requestDetail.getQuantity();
+
+            // Find available book instances for this edition
+            List<BookInstance> availableInstances = bookInstanceRepository
+                    .findByEditionIdAndStatusOrderByAcquiredDateAsc(edition.getId(), BookStatus.AVAILABLE);
+
+            if (availableInstances.size() < requestedQuantity) {
+                insufficientBooks.add(String.format("'%s' (yêu cầu: %d, có sẵn: %d)", 
+                        edition.getTitle(), requestedQuantity, availableInstances.size()));
+            } else {
+                // Store the instances we will use
+                availableInstancesMap.put(edition.getId(), 
+                        availableInstances.subList(0, requestedQuantity));
+            }
+        }
+
+        // If any edition doesn't have enough books, throw exception with detailed message
+        if (!insufficientBooks.isEmpty()) {
+            String errorMessage = messageSource.getMessage(
+                "admin.borrowing.error.insufficient_books", 
+                new Object[]{String.join(", ", insufficientBooks)}, 
+                "Không thể phê duyệt: " + String.join(", ", insufficientBooks), 
+                LocaleContextHolder.getLocale());
             throw new IllegalStateException(errorMessage);
         }
 
         // All books are available, proceed with approval
-        // Update borrowing receipt status
-        receipt.setStatus(BorrowingStatus.APPROVED);
+        List<BorrowingDetail> borrowingDetails = new ArrayList<>();
 
-        // Update status of all book instances and decrease availableQuantity
-        receipt.getBorrowingDetails().forEach(detail -> {
-            BookInstance bookInstance = detail.getBookInstance();
-            Edition edition = bookInstance.getEdition();
+        for (BorrowingRequestDetail requestDetail : requestDetails) {
+            Edition edition = requestDetail.getEdition();
+            List<BookInstance> instancesToReserve = availableInstancesMap.get(edition.getId());
 
-            // Update book instance status: AVAILABLE → RESERVED (when approve request)
-            bookInstance.setStatus(BookStatus.RESERVED);
-            bookInstanceRepository.save(bookInstance);
+            // Create borrowing details and reserve book instances
+            for (BookInstance instance : instancesToReserve) {
+                // Create borrowing detail
+                BorrowingDetail detail = BorrowingDetail.builder()
+                        .borrowingReceipt(receipt)
+                        .bookInstance(instance)
+                        .build();
+                borrowingDetails.add(detail);
+                borrowingDetailRepository.save(detail);
 
-            // Check availableQuantity before decreasing
-            if (edition.getAvailableQuantity() <= 0) {
-                throw new IllegalStateException(
-                        "Số lượng sách khả dụng không đủ để cho mượn: " + edition.getTitle());
+                // Update book instance status to RESERVED
+                instance.setStatus(BookStatus.RESERVED);
+                bookInstanceRepository.save(instance);
             }
-            edition.setAvailableQuantity(edition.getAvailableQuantity() - 1);
-            editionRepository.save(edition); // Save edition to update availableQuantity
-        });
 
+            // Update edition's available quantity
+            edition.setAvailableQuantity(edition.getAvailableQuantity() - requestDetail.getQuantity());
+            editionRepository.save(edition);
+        }
+
+        // Update borrowing receipt status to APPROVED
+        receipt.setStatus(BorrowingStatus.APPROVED);
         borrowingReceiptRepository.save(receipt);
+
+        log.info("Phê duyệt thành công phiếu mượn ID: {}, tổng cộng {} cuốn sách được đặt chỗ", 
+                receipt.getId(), borrowingDetails.size());
 
         // TODO: Send email notification to user
         // emailService.sendApprovalNotification(receipt.getUser().getEmail(), receipt);

--- a/library_management/src/main/resources/messages_borrowing_en.properties
+++ b/library_management/src/main/resources/messages_borrowing_en.properties
@@ -108,3 +108,20 @@ admin.borrowing.error.generic_system_error=A system error has occurred. Please t
 admin.borrowing.validation.borrowingDetailId.notNull=Borrowing detail ID cannot be empty
 admin.borrowing.validation.action.notBlank=Action cannot be blank
 admin.borrowing.validation.extendDays.positive=Extension days must be greater than 0
+
+admin.borrowing.request.details.title=Borrowing Request Details
+admin.borrowing.error.insufficient_books=Insufficient books available to approve the request
+admin.borrowing.books.table.quantity=Requested Quantity
+admin.borrowing.books.table.available=Available
+admin.borrowing.books.table.available_at=Available At
+admin.borrowing.books.no_request_books=No book requests in this borrowing receipt.
+admin.borrowing.status.pending=Pending
+admin.borrowing.status.rejected=Rejected
+admin.borrowing.error.insufficient_books_prefix=Cannot approve request: Not enough available books for
+error.receiptNotFound=Borrowing receipt with ID: {0} not found
+error.receipt.approve.notPending=Only requests with PENDING status can be approved
+error.receipt.noRequestDetails=Cannot find any borrowing request details for this receipt
+
+admin.borrowing.error.pending_status_required=Only requests with pending status can be approved
+admin.borrowing.error.no_request_details=No request details found
+admin.borrowing.error.insufficient_book_detail_format=''{0}'' (requested: {1}, available: {2})

--- a/library_management/src/main/resources/messages_borrowing_vi.properties
+++ b/library_management/src/main/resources/messages_borrowing_vi.properties
@@ -108,3 +108,20 @@ admin.borrowing.error.generic_system_error=Đã có lỗi hệ thống xảy ra.
 admin.borrowing.validation.borrowingDetailId.notNull=ID chi tiết mượn không được để trống
 admin.borrowing.validation.action.notBlank=Hành động không được để trống
 admin.borrowing.validation.extendDays.positive=Số ngày gia hạn phải lớn hơn 0
+
+admin.borrowing.request.details.title=Chi tiết yêu cầu mượn
+admin.borrowing.error.insufficient_books=Không đủ sách có sẵn để phê duyệt yêu cầu
+admin.borrowing.books.table.quantity=Số lượng yêu cầu
+admin.borrowing.books.table.available=Có sẵn
+admin.borrowing.books.table.available_at=Có sẵn lúc đó
+admin.borrowing.books.no_request_books=Không có yêu cầu sách nào trong phiếu mượn này.
+admin.borrowing.status.pending=Chờ phê duyệt
+admin.borrowing.status.rejected=Đã từ chối
+admin.borrowing.error.insufficient_books_prefix=Không thể phê duyệt: Không đủ sách có sẵn cho
+error.receiptNotFound=Không tìm thấy phiếu mượn với ID: {0}
+error.receipt.approve.notPending=Chỉ có thể phê duyệt yêu cầu đang ở trạng thái Chờ phê duyệt
+error.receipt.noRequestDetails=Không tìm thấy chi tiết yêu cầu mượn cho phiếu này
+
+admin.borrowing.error.pending_status_required=Chỉ có thể phê duyệt yêu cầu đang ở trạng thái chờ phê duyệt
+admin.borrowing.error.no_request_details=Không tìm thấy chi tiết yêu cầu mượn
+admin.borrowing.error.insufficient_book_detail_format=''{0}'' (yêu cầu: {1}, có sẵn: {2})

--- a/library_management/src/main/resources/templates/admin/borrowing/fragments/_book_list_panel.html
+++ b/library_management/src/main/resources/templates/admin/borrowing/fragments/_book_list_panel.html
@@ -347,10 +347,112 @@
                 </form>
               </div>
 
+              <div th:if="${receipt.status() == T(com.group2.library_management.entity.enums.BorrowingStatus).PENDING}">
+                <table class="table table-hover book-info-table">
+                  <thead>
+                    <tr>
+                      <th class="col-title" style="width: 34%" th:text="#{admin.borrowing.books.table.book_name}">
+                        Tên sách
+                      </th>
+                      <th class="col-isbn" style="width: 18%" th:text="#{admin.borrowing.books.table.isbn}">
+                        ISBN
+                      </th>
+                      <th class="col-quantity text-center" style="width: 15%" th:text="#{admin.borrowing.books.table.quantity}">
+                        Số lượng yêu cầu
+                      </th>
+                      <th class="col-available text-center" style="width: 15%" th:text="#{admin.borrowing.books.table.available}">
+                        Có sẵn
+                      </th>
+                      <th class="col-status text-center" style="width: 18%" th:text="#{admin.borrowing.books.table.status}">
+                        Trạng thái
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr th:if="${receipt.borrowingRequestDetails() == null or #lists.isEmpty(receipt.borrowingRequestDetails())}">
+                      <td colspan="5" class="text-center py-3" th:text="#{admin.borrowing.books.no_request_books}">
+                        Không có yêu cầu sách nào trong phiếu mượn này.
+                      </td>
+                    </tr>
+                    <tr th:each="requestDetail : ${receipt.borrowingRequestDetails()}">
+                      <td class="col-title">
+                        <a th:href="@{/admin/editions/{id}(id=${requestDetail.editionId()})}" 
+                          th:text="${requestDetail.title()}" 
+                          target="_blank" 
+                          class="text-primary text-decoration-none"
+                          th:title="#{admin.borrowing.books.view_detail}"></a>
+                      </td>
+                      <td class="col-isbn" th:text="${requestDetail.isbn() ?: 'N/A'}"></td>
+                      <td class="col-quantity text-center">
+                        <span class="badge badge-primary badge-pill px-3 py-2" th:text="${requestDetail.quantity()}"></span>
+                      </td>
+                      <td class="col-available text-center">
+                        <span class="badge badge-success badge-pill px-3 py-2" 
+                              th:text="${@bookInstanceRepository.countByEditionIdAndStatus(requestDetail.editionId(), T(com.group2.library_management.entity.enums.BookStatus).AVAILABLE)}"></span>
+                      </td>
+                      <td class="col-status text-center">
+                        <span class="badge badge-warning badge-pill px-3 py-2" th:text="#{admin.borrowing.status.pending}">
+                          Chờ phê duyệt
+                        </span>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+
+              <div th:if="${receipt.status() == T(com.group2.library_management.entity.enums.BorrowingStatus).REJECTED}">
+                <table class="table table-hover book-info-table">
+                  <thead>
+                    <tr>
+                      <th class="col-title" style="width: 40%" th:text="#{admin.borrowing.books.table.book_name}">
+                        Tên sách
+                      </th>
+                      <th class="col-isbn" style="width: 20%" th:text="#{admin.borrowing.books.table.isbn}">
+                        ISBN
+                      </th>
+                      <th class="col-quantity text-center" style="width: 20%" th:text="#{admin.borrowing.books.table.quantity}">
+                        Số lượng yêu cầu
+                      </th>
+                      <th class="col-status text-center" style="width: 20%" th:text="#{admin.borrowing.books.table.status}">
+                        Trạng thái
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr th:if="${receipt.borrowingRequestDetails() == null or #lists.isEmpty(receipt.borrowingRequestDetails())}">
+                      <td colspan="4" class="text-center py-3" th:text="#{admin.borrowing.books.no_request_books}">
+                        Không có yêu cầu sách nào trong phiếu mượn này.
+                      </td>
+                    </tr>
+                    <tr th:each="requestDetail : ${receipt.borrowingRequestDetails()}">
+                      <td class="col-title">
+                        <a th:href="@{/admin/editions/{id}(id=${requestDetail.editionId()})}" 
+                          th:text="${requestDetail.title()}" 
+                          target="_blank" 
+                          class="text-primary text-decoration-none"
+                          th:title="#{admin.borrowing.books.view_detail}"></a>
+                      </td>
+                      <td class="col-isbn" th:text="${requestDetail.isbn() ?: 'N/A'}"></td>
+                      <td class="col-quantity text-center">
+                        <span class="badge badge-primary badge-pill px-3 py-2" th:text="${requestDetail.quantity()}"></span>
+                      </td>
+                      <td class="col-status text-center">
+                        <span class="badge badge-danger badge-pill px-3 py-2" th:text="#{admin.borrowing.status.rejected}">
+                          Đã từ chối
+                        </span>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+
+
               <div
                 th:unless="${receipt.status() == T(com.group2.library_management.entity.enums.BorrowingStatus).APPROVED or 
                                      receipt.status() == T(com.group2.library_management.entity.enums.BorrowingStatus).BORROWED or
-                                     receipt.status() == T(com.group2.library_management.entity.enums.BorrowingStatus).OVERDUE}"
+                                     receipt.status() == T(com.group2.library_management.entity.enums.BorrowingStatus).OVERDUE or
+                                     receipt.status() == T(com.group2.library_management.entity.enums.BorrowingStatus).PENDING or
+                                     receipt.status() == T(com.group2.library_management.entity.enums.BorrowingStatus).REJECTED}"
               >
                 <table class="table table-hover book-info-table">
                   <thead>


### PR DESCRIPTION
## ✅ Checklist tự review pull trước khi ready để trainer review (Java Spring Boot)
- [x] Sử dụng **thụt lề 4 spaces** đồng nhất ở tất cả các files `.java`, `.xml`, `.html`, `.properties`, v.v. (cấu hình lại IntelliJ/VSCode nếu chưa setup).
- [x] Cuối mỗi file cần có **end line** (`\n`) để tránh lỗi đỏ khi diff trên Git.
- [x] Mỗi dòng nếu quá dài thì cần xuống dòng (tối đa **100 ký tự/dòng**, cài đặt wrap line trong IDE nếu cần).
- [x] `.gitignore` các file nhạy cảm (VD: `application-secret.properties`, `.env`, `/target/`, `.log`, `.class`, ...).
- [x] Tham khảo và tuân theo Java Coding Convention:
  - https://google.github.io/styleguide/javaguide.html
  - hoặc https://www.oracle.com/java/technologies/javase/codeconventions-contents.html
- [x] Kiểm tra mỗi pull request **chỉ có 1 commit**, nếu nhiều hơn hãy dùng `git rebase -i` để gộp commit.
- [x] Cài đặt `Checkstyle`, `PMD`, hoặc plugin Java linter tương ứng trong IDE để kiểm tra coding convention. Format lại trước khi gửi pull.
- [x] Nếu làm việc nhóm, mỗi pull cần **ít nhất 1 APPROVED** từ thành viên khác trong nhóm.

---
## Related Tickets
- [#92086](https://edu-redmine.sun-asterisk.vn/issues/92086)

## WHAT (optional)
- Thay đổi và nâng cấp quy trình chấp nhận yêu cầu mượn sách để phù hợp với luồng nghiệp vụ mới, nơi người dùng chỉ yêu cầu theo phiên bản sách (Edition) và số lượng. Hệ thống sẽ tự động tìm và phân bổ các bản sao sách vật lý có sẵn trong kho khi Admin phê duyệt.
- Quy trình mượn sách thay đổi: Người dùng chỉ yêu cầu theo `Edition` và số lượng, không chọn `Book Instance` cụ thể.
- Phiếu mượn ở trạng thái "Chờ phê duyệt" (`pending`) sẽ chứa danh sách các `edition_id` và số lượng tương ứng.

## HOW
- Chỉnh sửa `BorrowingReceiptServiceImpl` để hệ thống tự động tìm và đặt trước các bản sách (`BookInstance`) có sẵn phù hợp với `Edition` và số lượng trong yêu cầu khi admin nhấn "Chấp nhận".
- Thêm bước kiểm tra trước (pre-check) trong một transaction để xác thực số lượng sách. Nếu thiếu sách, toàn bộ giao dịch sẽ được rollback và hiển thị lỗi rõ ràng cho admin.
- Điều chỉnh file `book_list_panel.html` để hiển thị các bảng khác nhau tùy theo trạng thái:
    - Khi `PENDING`: Hiển thị danh sách yêu cầu (`BorrowingRequestDetail`).
    - Khi `APPROVED` trở đi: Hiển thị danh sách các bản sách vật lý đã được hệ thống phân bổ (`BorrowingDetail`).
- Thêm các key I18n cho thông báo lỗi và văn bản giao diện mới.

## WHY (optional)
- Quy trình cũ yêu cầu client phải chọn thủ công từng bản sách, không hiệu quả và không còn phù hợp với logic mới (người dùng chỉ yêu cầu theo đầu sách và số lượng).
- Thay đổi này tự động hóa việc phân bổ sách, đảm bảo tính toàn vẹn dữ liệu qua transaction, và cung cấp một giao diện trực quan hơn cho admin bằng cách tách biệt rõ ràng giữa "yêu cầu" và "sách đã được gán".

## Evidence (Screenshot or Video)
- Có thể phê duyệt
<img width="1027" height="509" alt="Screenshot from 2025-08-27 08-36-39" src="https://github.com/user-attachments/assets/e8a402da-2cbd-4f26-aa27-80db56e388a4" />
<img width="1021" height="534" alt="Screenshot from 2025-08-27 08-36-48" src="https://github.com/user-attachments/assets/8f4274cb-5f14-4662-9818-c95070aac954" />
<img width="1007" height="582" alt="Screenshot from 2025-08-27 08-36-55" src="https://github.com/user-attachments/assets/c932234b-2229-467f-9522-93356fb157d3" />
- Không thể phê duyệt
<img width="1036" height="515" alt="Screenshot from 2025-08-27 08-41-05" src="https://github.com/user-attachments/assets/b48b3040-54ac-4957-8ed1-89719ddc58ce" />
<img width="1005" height="504" alt="Screenshot from 2025-08-27 08-41-12" src="https://github.com/user-attachments/assets/b57b8b21-94f4-46ef-abd5-444ad9f09564" />
- Từ chối
<img width="1041" height="594" alt="Screenshot from 2025-08-27 08-41-26" src="https://github.com/user-attachments/assets/0fae530f-a0b8-4fbb-9c13-c210fa725880" />
<img width="1037" height="589" alt="Screenshot from 2025-08-27 08-41-38" src="https://github.com/user-attachments/assets/475013f6-fc34-44e4-ac8f-a2d52a64154d" />
<img width="1029" height="483" alt="Screenshot from 2025-08-27 08-41-43" src="https://github.com/user-attachments/assets/89f27ff7-1cf5-47a2-a24e-d18a69857a5f" />
